### PR TITLE
state_of_js에 other_tools 추가

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,3 +1,3 @@
 id: ko-KR
 label: 한국어
-translators: ["eterv", "icepeng", "Jcurver", "firepunch", "plrs9816", "Heunsig"]
+translators: ["eterv", "icepeng", "Jcurver", "firepunch", "plrs9816", "Heunsig", "gunhoflash"]

--- a/state_of_js.yml
+++ b/state_of_js.yml
@@ -582,6 +582,131 @@ translations:
   # Other Tools
   ###########################################################################
 
+  - key: other_tools.edge_runtimes.description
+    t: 어떤 엣지나 서버리스 런타임을 주로 사용하시나요?
+  - key: other_tools.edge_runtimes
+    t: 자바스크립트 엣지/서버리스 런타임
+  - key: other_tools.hosting.question
+    t: 자바스크립트 앱을 호스트하기 위해 다음 중 어떤 서비스를 사용하셨나요?
+  - key: other_tools.hosting
+    t: 호스팅 서비스
+  - key: other_tools.ai_tools.question
+    t: 코드 작성을 위해 다음 중 어떤 AI 도구를 주로 사용하시나요?
+  - key: other_tools.ai_tools
+    t: AI 도구
+  - key: other_tools.backend_frameworks.others
+    t: 기타 백엔드 프레임워크
+  - key: other_tools.backend_frameworks.description
+    t: API 생성 및 백엔드 관리를 위한 프레임워크
+  - key: other_tools.backend_frameworks
+    t: 백엔드 프레임워크
+  - key: other_tools.data_fetching.others
+    t: 기타 데이터 페칭 라이브러리
+  - key: other_tools.data_fetching.description
+    t: 데이터 페칭 및 캐싱을 관리하는 라이브러리
+  - key: other_tools.data_fetching
+    t: 데이터 페칭
+  - key: other_tools.graphics_animation.others
+    t: 기타 그래픽 & 애니메이션 라이브러리
+  - key: other_tools.graphics_animation.description
+    t: 그래픽과 애니메이션을 위한 라이브러리
+  - key: other_tools.graphics_animation
+    t: 그래픽 & 애니메이션
+  - key: other_tools.data_visualization.others
+    t: 기타 데이터 시각화 라이브러리
+  - key: other_tools.data_visualization.description
+    t: 차트를 비롯한 데이터 시각화를 위한 라이브러리
+  - key: other_tools.data_visualization
+    t: 데이터 시각화
+  - key: other_tools.date_management.others
+    t: 기타 날짜 관리 라이브러리
+  - key: other_tools.date_management.description
+    t: 날짜 및 시간대 관리를 위한 라이브러리
+  - key: other_tools.date_management
+    t: 날짜 라이브러리
+  - key: other_tools.backend_as_a_service.others
+    t: 기타 BaaS 제공자
+  - key: other_tools.backend_as_a_service.description
+    t: 데이터를 호스팅하고, 데이터에 접근할 수 있도록 클라이언트 API를 제공하는 서비스
+  - key: other_tools.backend_as_a_service
+    t: Backend-as-a-Service 제공자
+  - key: other_tools.form_factors.description
+    t: 어떤 폼팩터나 환경에서 테스트 하시나요?
+  - key: other_tools.form_factors
+    t: 테스트 환경
+  - key: other_tools.package_registries.others.description
+    t: 기타 답변 (자유 입력)
+  - key: other_tools.package_registries.others
+    t: 기타 패키지 저장소
+  - key: other_tools.package_registries.description
+    t: 주로 어떤 패키지 저장소에서 패키지를 가져오시나요?
+  - key: other_tools.package_registries
+    t: 패키지 저장소
+  - key: other_tools.runtimes.others.description
+    t: 기타 답변 (자유 입력)
+  - key: other_tools.runtimes.others
+    t: 기타 런타임
+  - key: other_tools.runtimes.description
+    t: 주로 어떤 엔진/런타임/실행환경을 사용하시나요?
+  - key: other_tools.runtimes
+    t: 자바스크립트 런타임
+  - key: other_tools.javascript_flavors.others.description
+    t: 기타 답변 (자유 입력)
+  - key: other_tools.javascript_flavors.others
+    t: 기타 자바스크립트 취향
+  - key: other_tools.javascript_flavors.description
+    t: 자바스크립트로 컴파일되는 언어
+  - key: other_tools.javascript_flavors
+    t: 자바스크립트 취향
+  - key: other_tools.non_js_languages.others.description
+    t: 기타 답변 (자유 입력)
+  - key: other_tools.non_js_languages.others
+    t: 기타 언어
+  - key: other_tools.non_js_languages.description
+    t: 어떤 다른 언어를 사용하시나요?
+  - key: other_tools.non_js_languages
+    t: 자바스크립트 외 언어
+  - key: other_tools.build_tools.others.description
+    t: 기타 답변 (자유 입력)
+  - key: other_tools.build_tools.others
+    t: 기타 빌드 도구
+  - key: other_tools.build_tools.description
+    t: 어떤 빌드 도구를 사용하시나요?
+  - key: other_tools.build_tools
+    t: 빌드 도구
+  - key: other_tools.browsers.others.description
+    t: 기타 답변 (자유 입력)
+  - key: other_tools.browsers.others
+    t: 기타 브라우저
+  - key: other_tools.browsers.description
+    t: 초기 개발 과정에서 주로 어떤 브라우저를 사용하시나요?
+  - key: other_tools.browsers
+    t: 브라우저
+  - key: other_tools.utilities.others.description
+    t: 기타 유틸리티 (자유 입력)
+  - key: other_tools.utilities.others
+    t: 기타 유틸리티
+  - key: other_tools.utilities.description
+    t: 주로 어떤 유틸리티나 도구를 사용하시나요?
+  - key: other_tools.utilities
+    t: 유틸리티
+  - key: other_tools.text_editors.others.description
+    t: 기타 답변 (자유 입력)
+  - key: other_tools.text_editors.others
+    t: 기타 텍스트 편집기
+  - key: other_tools.text_editors.description
+    t: 주로 어떤 텍스트 편집기를 사용하시나요?
+  - key: other_tools.text_editors
+    t: 텍스트 편집기
+  - key: other_tools.libraries.others.description
+    t: 기타 답변 (자유 입력)
+  - key: other_tools.libraries.others
+    t: 기타 라이브러리
+  - key: other_tools.libraries.description
+    t: 주로 어떤 라이브러리를 사용하시나요?
+  - key: other_tools.libraries
+    t: 라이브러리
+
   - key: tools_others.runtimes
     t: 자바스크립트 런타임
   - key: tools_others.runtimes.description

--- a/state_of_js.yml
+++ b/state_of_js.yml
@@ -707,71 +707,6 @@ translations:
   - key: other_tools.libraries
     t: 라이브러리
 
-  - key: tools_others.runtimes
-    t: 자바스크립트 런타임
-  - key: tools_others.runtimes.description
-    t: 어느 엔진/런타임/실행 환경을 주로 사용하나요?
-  - key: tools_others.runtimes.others
-    t: 기타 런타임
-  - key: tools_others.runtimes.others.description
-    t: 기타 대답 (자유 입력).
-
-  - key: tools_others.package_registries
-    t: 패키지 저장소
-  - key: tools_others.package_registries.description
-    t: 주로 어느 패키지 저장소에서 패키지를 가져오나요?
-  - key: tools_others.package_registries.others
-    t: 기타 패키지 저장소
-  - key: tools_others.package_registries.others.description
-    t: 기타 대답 (자유 입력).
-
-  - key: tools_others.form_factors
-    aliasFor: environments.form_factors
-  - key: tools_others.form_factors.description
-    aliasFor: environments.form_factors.description
-
-  - key: tools_others.backend_as_a_service
-    t: Backend-as-a-Service 공급자
-  - key: tools_others.backend_as_a_service.description
-    t: Services that host your data and offer a client API to access it.
-  - key: tools_others.backend_as_a_service.others
-    t: 기타 BaaS 공급자
-
-  - key: tools_others.date_management
-    t: 날짜 관리
-  - key: tools_others.date_management.description
-    t: 날짜 및 시간대 관리에 도움이 되는 라이브러리.
-  - key: tools_others.date_management.others
-    t: 기타 날짜 관리 라이브러리
-
-  - key: tools_others.data_visualization
-    t: 데이터 시각화
-  - key: tools_others.data_visualization.description
-    t: 차트 및 기타 데이터 시각화에 도움이 되는 라이브러리.
-  - key: tools_others.data_visualization.others
-    t: 기타 데이터 시각화 라이브러리
-
-  - key: tools_others.graphics_animation
-    t: 그래픽 & 애니매이션
-  - key: tools_others.graphics_animation.description
-    t: 그래픽 및 애니메이션 전용 라이브러리.
-  - key: tools_others.graphics_animation.others
-    t: 기타 그래픽 & 애니매이션 라이브러리
-
-  - key: tools_others.data_fetching
-    t: 데이터 fetching
-  - key: tools_others.data_fetching.description
-    t: 데이터 fetching 및 캐싱을 관리하는 라이브러리.
-  - key: tools_others.data_fetching.others
-    t: 기타 데이터 fetching 라이브러리
-
-  - key: tools_others.backend_frameworks
-    aliasFor: sections.back_end_frameworks.title
-  - key: tools_others.backend_frameworks.description
-    t: API 생성 및 백엔드 관리를 위한 프레임워크
-  - key: tools_others.backend_frameworks.others
-    t: 기타 백엔드 프레임워크
-
   ###########################################################################
   # Usage
   ###########################################################################
@@ -792,13 +727,6 @@ translations:
     t: 자바스크립트/타입스크립트 비율
   - key: usage.js_ts_balance.question
     t: JavaScript와 TypeScript 코드 작성 사이에 시간을 어떻게 나누나요?
-
-  - key: tools_others.edge_runtimes
-    t: 자바스크립트 엣지/서버리스 런타임
-  - key: tools_others.edge_runtimes.question
-    t: 어떤 엣지 또는 서버리스 런타임을 정기적으로 사용하십니까?
-  - key: tools_others.edge_runtimes.others
-    t: 기타 엣지 런타임
 
   - key: usage.usage_type
     t: 자바스크립트 사용법


### PR DESCRIPTION
state_of_js.yml 에 `other_tools.*` 에 대한 번역을 추가합니다.

https://graphiql.devographics.com/ 에서
```graphql
query GetLocaleData {
  locale(localeId: ko_KR) {
    completion
    totalCount
    translatedCount
    translators
    untranslatedKeys
    strings {
      key
      aliasFor
      context
      tClean
      t
      tHtml
      isFallback
    }
  }
}
```
쿼리하여 나온 목록 중
- key가 `other_tools.*` 이고
- context가 `state_of_js`인

총 62 항목에 대해 번역했습니다.

한편, 기존의 `tools_others.*` 항목은 모두 `other_tools.*`로부터의 alias가 설정되어 있고, 올해 설문부터 `tools_others.*` 대신 `other_tools.*`를 사용하는 것 같아 삭제했습니다.

혹시 이슈 있을지 확인 부탁드립니다!
